### PR TITLE
Fix error catching in types with overidden __dir__

### DIFF
--- a/Pyrado/pyrado/utils/exceptions.py
+++ b/Pyrado/pyrado/utils/exceptions.py
@@ -62,13 +62,13 @@ class BaseErr(Exception):
                 # Use generator to avoid errors
                 # noinspection PyBroadException
                 def list_attrs():
-                    for attr in dir(m_self):
-                        # try to access attribute
-                        try:
+                    try:
+                        for attr in dir(m_self):
+                            # try to access attribute
                             yield attr, getattr(m_self, attr)
-                        except Exception:
-                            # Simply skip errors here, we only do this for error reporting
-                            pass
+                    except Exception:
+                        # Simply skip errors here, we only do this for error reporting
+                        pass
 
                 name = first_match_name(list_attrs())
 


### PR DESCRIPTION
This can happen with TypeErrs raised with objects like
pytorchs.nn.modules, which override __dir__ (see
https://github.com/pytorch/pytorch/blob/4ed7f36ed181ee784f9904d5eabf073701e1fb78/torch/nn/modules/module.py#L1401). 

This can lead to a cryptic error message such as `torch.nn.modules.module.ModuleAttributeError: 'DiscreteActQValPolicy' object has no attribute '_parameters' ` instead of e.g. `pyrado.utils.exceptions.TypeErr: Expected the type of the input to be DiscreteSpace but received BoxSpace!`