### PR TITLE
Small improvements

### DIFF
--- a/Pyrado/pyrado/exploration/normal_noise.py
+++ b/Pyrado/pyrado/exploration/normal_noise.py
@@ -61,7 +61,7 @@ class DiagNormalNoise(nn.Module):
             raise pyrado.TypeErr(given=std_init, expected_type=[float, int, to.Tensor])
         if isinstance(std_init, to.Tensor) and not std_init.size() == noise_dim:
             raise pyrado.ShapeErr(given=std_init, expected_match=to.empty(noise_dim))
-        if not (isinstance(std_init, float) and std_init > 0 or isinstance(std_init, to.Tensor) and all(std_init > 0)):
+        if not (isinstance(std_init, (float, int)) and std_init > 0 or isinstance(std_init, to.Tensor) and all(std_init > 0)):
             raise pyrado.ValueErr(given=std_init, g_constraint='0')
         if not isinstance(std_min, (float, to.Tensor)):
             raise pyrado.TypeErr(given=std_min, expected_type=[float, to.Tensor])
@@ -87,7 +87,7 @@ class DiagNormalNoise(nn.Module):
 
         # Initialize parameters
         self.log_std_init = to.log(to.tensor(std_init)) if isinstance(std_init, float) else to.log(std_init)
-        self.std_min = to.tensor(std_min) if isinstance(std_min, float) else std_min
+        self.std_min = to.tensor(std_min, dtype=to.get_default_dtype()) if isinstance(std_min, (float, int)) else std_min
         if not isinstance(self.log_std_init, to.Tensor):
             raise pyrado.TypeErr(given=self.log_std_init, expected_type=to.Tensor)
         if not isinstance(self.std_min, to.Tensor):

--- a/Pyrado/pyrado/exploration/uniform_noise.py
+++ b/Pyrado/pyrado/exploration/uniform_noise.py
@@ -42,7 +42,7 @@ class UniformNoise(nn.Module):
     def __init__(self,
                  use_cuda: bool,
                  noise_dim: [int, tuple],
-                 halfspan_init: [float, to.Tensor],
+                 halfspan_init: [float, int, to.Tensor],
                  halfspan_min: [float, to.Tensor] = 0.01,
                  train_mean: bool = False,
                  learnable: bool = True):
@@ -56,9 +56,9 @@ class UniformNoise(nn.Module):
         :param train_mean: `True` if the noise should have an adaptive nonzero mean, `False` otherwise
         :param learnable: `True` if the parameters should be tuneable (default), `False` for shallow use (just sampling)
         """
-        if not isinstance(halfspan_init, (float, to.Tensor)):
+        if not isinstance(halfspan_init, (float, int, to.Tensor)):
             raise pyrado.TypeErr(given=halfspan_init, expected_type=[float, to.Tensor])
-        if not (isinstance(halfspan_init, float) and halfspan_init > 0 or
+        if not (isinstance(halfspan_init, (int, float)) and halfspan_init > 0 or
                 isinstance(halfspan_init, to.Tensor) and all(halfspan_init > 0)):
             raise pyrado.ValueErr(given=halfspan_init, g_constraint='0')
         if not isinstance(halfspan_min, (float, to.Tensor)):
@@ -87,7 +87,7 @@ class UniformNoise(nn.Module):
             self.mean = None
 
         # Initialize parameters
-        self.log_halfspan_init = to.log(to.tensor(halfspan_init)) if isinstance(halfspan_init, float) else to.log(
+        self.log_halfspan_init = to.log(to.tensor(halfspan_init, dtype=to.get_default_dtype())) if isinstance(halfspan_init, (int, float)) else to.log(
             halfspan_init)
         self.halfspan_min = to.tensor(halfspan_min) if isinstance(halfspan_min, float) else halfspan_min
         if not isinstance(self.log_halfspan_init, to.Tensor):


### PR DESCRIPTION
This is a collection of small improvements I found while looking around `SimuRLacra`
- 1f2a857ac04825cc6b7e0c99b0f453a972876ee1: Allow the usage of `int` for the initial standard deviation of noise generators.