### PR TITLE
Added custom reward function for QCartPoleSwingUp

### DIFF
--- a/Pyrado/pyrado/tasks/reward_functions.py
+++ b/Pyrado/pyrado/tasks/reward_functions.py
@@ -410,18 +410,22 @@ class ForwardVelocityRewFcn(RewFcn):
         return float(fwd_vel_rew - ctrl_cost)
 
 
-class QCartPoleSwingUpCustomRewFcn(RewFcn):
+class QCartPoleSwingUpRewFcn(RewFcn):
     """ Custom reward function for QCartPoleSwingUpSim. """
 
-    def __init__(self, factor=0.9):
+    def __init__(self, factor: float = 0.9):
         """
         Constructor
+
         :param factor: weighting factor of rotation error to position error
         """
         self.factor = factor
 
     def __call__(self, err_s: np.ndarray, err_a: np.ndarray, remaining_steps: int = None) -> float:
-        assert isinstance(err_s, np.ndarray) and isinstance(err_a, np.ndarray)
+        if not isinstance(err_s, np.ndarray):
+            raise pyrado.TypeErr(given=err_s, expected_type=np.ndarray)
+        if not isinstance(err_a, np.ndarray):
+            raise pyrado.TypeErr(given=err_a, expected_type=np.ndarray)
 
         # Reward should be roughly between [0, 1]
         return self.factor*(1-np.abs(err_s[1]/np.pi)**2) + (1-self.factor)*(np.abs(err_s[0])) 

--- a/Pyrado/pyrado/tasks/reward_functions.py
+++ b/Pyrado/pyrado/tasks/reward_functions.py
@@ -428,4 +428,4 @@ class QCartPoleSwingUpRewFcn(RewFcn):
             raise pyrado.TypeErr(given=err_a, expected_type=np.ndarray)
 
         # Reward should be roughly between [0, 1]
-        return self.factor*(1-np.abs(err_s[1]/np.pi)**2) + (1-self.factor)*(np.abs(err_s[0])) 
+        return float(self.factor * (1 - np.abs(err_s[1] / np.pi) ** 2) + (1 - self.factor) * (np.abs(err_s[0])))

--- a/Pyrado/pyrado/tasks/reward_functions.py
+++ b/Pyrado/pyrado/tasks/reward_functions.py
@@ -408,3 +408,20 @@ class ForwardVelocityRewFcn(RewFcn):
         self.last_x_pos = state[self._idx_x_pos]
 
         return float(fwd_vel_rew - ctrl_cost)
+
+
+class QCartPoleSwingUpCustomRewFcn(RewFcn):
+    """ Custom reward function for QCartPoleSwingUpSim. """
+
+    def __init__(self, factor=0.9):
+        """
+        Constructor
+        :param factor: weighting factor of rotation error to position error
+        """
+        self.factor = factor
+
+    def __call__(self, err_s: np.ndarray, err_a: np.ndarray, remaining_steps: int = None) -> float:
+        assert isinstance(err_s, np.ndarray) and isinstance(err_a, np.ndarray)
+
+        # Reward should be roughly between [0, 1]
+        return self.factor*(1-np.abs(err_s[1]/np.pi)**2) + (1-self.factor)*(np.abs(err_s[0])) 


### PR DESCRIPTION
Custom reward function with which we could solve QCartpoleSwingUp with PPO after about 60 epochs and a batch size of 72k samples.