### PR TITLE
No coverage in forks

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,6 +39,7 @@ jobs:
           fail_ci_if_error: true
       - name: Test & publish code coverage
         uses: paambaati/codeclimate-action@v2.7.5
+        if: github.repository_owner == 'famura'
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:


### PR DESCRIPTION
The test run fails in forks, due to the secrets not being available. This small change just deactivates uploading of the coverage when it is a cloned fork.