### PR TITLE
Fixed typo in ARPL.

### DIFF
--- a/Pyrado/pyrado/algorithms/meta/arpl.py
+++ b/Pyrado/pyrado/algorithms/meta/arpl.py
@@ -43,7 +43,7 @@ from pyrado.sampling.parallel_rollout_sampler import ParallelRolloutSampler
 from pyrado.sampling.sequences import *
 
 
-class ARPL(Algorithm, ExposedExSampler):
+class ARPL(Algorithm, ExposedSampler):
     """
     Adversarially Robust Policy Learning (ARPL)
 


### PR DESCRIPTION
Super class `ExposedExSampler` should be `ExposedSampler`.