### PR TITLE
Added an implementation of PDDR and improved RNN evaluate

### DIFF
--- a/Pyrado/pyrado/algorithms/meta/pddr.py
+++ b/Pyrado/pyrado/algorithms/meta/pddr.py
@@ -1,0 +1,328 @@
+# Copyright (c) 2020, Fabio Muratore, Honda Research Institute Europe GmbH, and
+# Technical University of Darmstadt.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of Fabio Muratore, Honda Research Institute Europe GmbH,
+#    or Technical University of Darmstadt, nor the names of its contributors may
+#    be used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL FABIO MURATORE, HONDA RESEARCH INSTITUTE EUROPE GMBH,
+# OR TECHNICAL UNIVERSITY OF DARMSTADT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+from copy import deepcopy
+from typing import Any, Optional
+
+import numpy as np
+import torch as to
+
+import pyrado
+from pyrado.algorithms.base import Algorithm, InterruptableAlgorithm
+from pyrado.domain_randomization.default_randomizers import create_default_randomizer
+from pyrado.domain_randomization.domain_randomizer import DomainRandomizer
+from pyrado.environments.base import Env
+from pyrado.exploration.stochastic_action import NormalActNoiseExplStrat
+from pyrado.logger.experiment import Experiment, ask_for_experiment
+from pyrado.logger.step import StepLogger
+from pyrado.policies.base import Policy
+from pyrado.sampling.parallel_rollout_sampler import ParallelRolloutSampler
+from pyrado.sampling.step_sequence import StepSequence
+from pyrado.utils.experiments import load_experiment
+from pyrado.utils.input_output import print_cbt
+
+
+class PDDR(InterruptableAlgorithm):
+    """ Policy Distillation with Domain Randomization (PDDR) """
+
+    name: str = "pddr"
+
+    def __init__(
+        self,
+        save_dir: str,
+        env: Env,
+        policy: Policy,
+        logger: StepLogger = None,
+        device: str = "cpu",
+        lr: float = 5e-4,
+        std_init: float = 0.15,
+        min_steps: int = 1500,
+        num_epochs: int = 10,
+        max_iter: int = 500,
+        num_teachers: int = 8,
+        num_cpu: int = 3,
+        teacher_extra: dict = None,
+        teacher_policy: Policy = None,
+        teacher_algo: callable = None,
+        teacher_algo_hparam: dict() = None,
+        randomizer: DomainRandomizer = None,
+    ):
+        """
+        Constructor
+
+        :param save_dir: directory to save the snapshots i.e. the results in
+        :param env: the environment which the policy operates
+        :param policy: policy to be updated
+        :param logger: logger for every step of the algorithm, if `None` the default logger will be created
+        :param device: device to use for updating the policy (cpu or gpu)
+        :param lr: (initial) learning rate for the optimizer which can be by modified by the scheduler.
+                    By default, the learning rate is constant.
+        :param std_init: initial standard deviation on the actions for the exploration noise
+        :param min_steps: minimum number of state transitions sampled per policy update batch
+        :param num_epochs: number of epochs (how often we iterate over the same batch)
+        :param max_iter: number of iterations (policy updates)
+        :param num_teachers: number of teachers that are used for distillation
+        :param num_cpu: number of cpu cores to use
+        :param teacher_extra: extra dict from PDDRTeachers algo. If provided, teachers are loaded from there
+        :param teacher_policy: policy to be updated (is duplicated for each teacher)
+        :param teacher_algo: algorithm class to be used for training the teachers
+        :param teacher_algo_hparam: hyperparams to be used for teacher_algo
+        :param randomizer: randomizer for sampling the teacher domain parameters. If None, the default one for env is used
+        """
+        if not isinstance(env, Env):
+            raise pyrado.TypeErr(given=env, expected_type=Env)
+        if not isinstance(policy, Policy):
+            raise pyrado.TypeErr(given=policy, expected_type=Policy)
+
+        # Call Algorithm's constructor.
+        super().__init__(
+            num_checkpoints=1, init_checkpoint=-1, save_dir=save_dir, max_iter=max_iter, policy=policy, logger=logger
+        )
+
+        # Store the inputs
+        self.min_steps = min_steps
+        self.num_epochs = num_epochs
+        self.num_teachers = num_teachers
+        self.num_cpu = num_cpu
+        self.device = device
+        self.env_real = env
+
+        self.teacher_policies = []
+        self.teacher_envs = []
+        self.teacher_expl_strats = []
+        self.teacher_critics = []
+        self.teacher_ex_dirs = []
+
+        # Teachers
+        if teacher_policy is not None and teacher_algo is not None and teacher_algo_hparam is not None:
+            if not isinstance(teacher_policy, Policy):
+                raise pyrado.TypeErr(given=teacher_policy, expected_type=Policy)
+            if not issubclass(teacher_algo, Algorithm):
+                raise pyrado.TypeErr(given=teacher_algo, expected_type=Algorithm)
+
+            if randomizer is None:
+                self.randomizer = create_default_randomizer(env)
+            else:
+                assert isinstance(randomizer, DomainRandomizer)
+                self.randomizer = randomizer
+
+            self.set_random_envs()
+
+            # Prepare folders
+            for idx in range(self.num_teachers):
+                os.makedirs(os.path.join(self.save_dir, f"teachers_{idx}"), exist_ok=True)
+
+            # Create teacher algos
+            self.algos = [
+                teacher_algo(
+                    save_dir=os.path.join(self.save_dir, f"teachers_{idx}"),
+                    env=self.teacher_envs[idx],
+                    policy=deepcopy(teacher_policy),
+                    logger=None,
+                    **deepcopy(teacher_algo_hparam),
+                )
+                for idx in range(self.num_teachers)
+            ]
+        elif teacher_extra is not None:
+            self.unpack_teachers(teacher_extra)
+            assert self.num_teachers == len(self.teacher_policies)
+            self.reset_checkpoint()
+        else:
+            self.load_teachers()
+            if self.num_teachers < len(self.teacher_policies):
+                print(
+                    f"You have loaded {len(self.teacher_policies)} teachers. Only the first {self.num_teachers} will be used!"
+                )
+                self.prune_teachers()
+            assert self.num_teachers == len(self.teacher_policies)
+            self.reset_checkpoint()
+
+        # Student
+        self._expl_strat = NormalActNoiseExplStrat(self._policy, std_init=std_init)
+        self._policy = self._policy.to(self.device)
+        self.optimizer = to.optim.Adam([{"params": self.policy.parameters()}], lr=lr)
+
+        # Environments
+        self.samplers = [
+            ParallelRolloutSampler(
+                self.teacher_envs[t],
+                deepcopy(self._expl_strat),
+                num_workers=int(self.num_cpu / self.num_teachers),
+                min_steps=self.min_steps,
+            )
+            for t in range(self.num_teachers)
+        ]
+
+        self.teacher_weights = np.ones(self.num_teachers)
+
+        # Distillation loss criterion
+        self.criterion = to.nn.KLDivLoss(log_target=True, reduction="batchmean")
+
+    @property
+    def expl_strat(self) -> NormalActNoiseExplStrat:
+        return self._expl_strat
+
+    def step(self, snapshot_mode: str, meta_info: dict = None):
+        """
+        Perform a single iteration of the algorithm. This includes collecting the data, updating the parameters, and
+        adding the metrics of interest to the logger. Does not update the `curr_iter` attribute.
+
+        :param snapshot_mode: determines when the snapshots are stored (e.g. on every iteration or on new highscore)
+        :param meta_info: is not `None` if this algorithm is run as a subroutine of a meta-algorithm,
+                          contains a dict of information about the current iteration of the meta-algorithm
+        """
+        # Save snapshot to save the correct iteration count
+        self.save_snapshot()
+
+        if self.curr_checkpoint == -1:
+            self.train_teachers(snapshot_mode, None)
+            self.reached_checkpoint()  # setting counter to 0
+
+        if self.curr_checkpoint == 0:
+            # Sample observations
+            ros, rets, all_lengths = self.sample()
+
+            # Log current progress
+            self.logger.add_value("max return", np.max(rets), 4)
+            self.logger.add_value("median return", np.median(rets), 4)
+            self.logger.add_value("avg return", np.mean(rets), 4)
+            self.logger.add_value("min return", np.min(rets), 4)
+            self.logger.add_value("std return", np.std(rets), 4)
+            self.logger.add_value("std var", self.expl_strat.std.item(), 4)
+            self.logger.add_value("avg rollout len", np.mean(all_lengths), 4)
+            self.logger.add_value("num total samples", np.sum(all_lengths))
+
+            # Save snapshot data
+            self.make_snapshot(snapshot_mode, np.mean(rets), meta_info)
+
+            # Update policy and value function
+            self.update(rollouts=ros)
+
+    def sample(self):
+        """ Samples observations from several samplers. """
+        ros = []
+        rets = []
+        all_lengths = []
+        for sampler in self.samplers:
+            samples = sampler.sample()
+            ros.append(samples)
+            rets.extend([sample.undiscounted_return() for sample in samples])
+            all_lengths.extend([sample.length for sample in samples])
+
+        return ros, np.array(rets), np.array(all_lengths)
+
+    def update(self, *args: Any, **kwargs: Any):
+        """ Update the policy's (and value functions') parameters based on the collected rollout data. """
+        obss = []
+        losses = []
+        for t in range(self.num_teachers):
+            concat_ros = StepSequence.concat(kwargs["rollouts"][t])
+            concat_ros.torch(data_type=to.get_default_dtype())
+            obss.append(concat_ros.get_data_values("observations")[: self.min_steps])
+
+        # Train student
+        for epoch in range(self.num_epochs):
+            self.optimizer.zero_grad()
+
+            loss = 0
+            for t_idx, teacher in enumerate(self.teacher_policies):
+                s_dist = self.expl_strat.action_dist_at(self.policy(obss[t_idx]))
+                s_act = s_dist.sample()
+                t_dist = self.teacher_expl_strats[t_idx].action_dist_at(teacher(obss[t_idx]))
+
+                l = self.teacher_weights[t_idx] * self.criterion(t_dist.log_prob(s_act), s_dist.log_prob(s_act))
+                loss += l
+                losses.append([t_idx, l.item()])
+            print(f"Epoch {epoch} Loss: {loss.item()}")
+            loss.backward()
+            self.optimizer.step()
+
+    def save_snapshot(self, meta_info: dict = None):
+        super().save_snapshot(meta_info)
+
+        pyrado.save(self.policy, "policy.pt", self.save_dir)
+
+        if meta_info is None:
+            # This algorithm instance is not a subroutine of another algorithm
+            pyrado.save(self.env_real, "env.pkl", self.save_dir)
+
+    def _train_teacher(self, idx: int, snapshot_mode: str = "latest", seed: int = None):
+        """ Wrapper for use of multiprocessing: Trains oe teacher. """
+        self.algos[idx].train(snapshot_mode=snapshot_mode, seed=seed)
+
+    def set_random_envs(self):
+        """ Creates random environments of the given type. """
+        self.randomizer.randomize(num_samples=self.num_teachers)
+        params = self.randomizer.get_params(fmt="dict", dtype="numpy")
+
+        for e in range(self.num_teachers):
+            self.teacher_envs.append(deepcopy(self.env_real))
+            print({key: value[e] for key, value in params.items()})
+            self.teacher_envs[e].domain_param = {key: value[e] for key, value in params.items()}
+
+    def train_teachers(self, snapshot_mode: str = "latest", seed: int = None):
+        for idx in range(self.num_teachers):
+            print_cbt(f"Training teacher {idx + 1} of {self.num_teachers}... ", "c")
+            self._train_teacher(idx, snapshot_mode, seed)
+
+        self.teacher_policies = [a.policy for a in self.algos]
+        self.teacher_expl_strats = [a.expl_strat for a in self.algos]
+        self.teacher_critics = [a.critic for a in self.algos]
+        self.teacher_ex_dirs = [a.save_dir for a in self.algos]
+
+    def load_teachers(self):
+        # Get the experiment's directory to load from
+        ex_dir = ask_for_experiment(max_display=10, env_name=self.env_real.name, perma=False)
+        self.load_teacher_experiment(ex_dir)
+        if len(self.teacher_policies) < self.num_teachers:
+            print(
+                f"You have loaded {len(self.teacher_policies)} teachers - load at least {self.num_teachers - len(self.teacher_policies)} more!"
+            )
+            self.load_teachers()
+
+    def load_teacher_experiment(self, exp: Experiment):
+        """ Load teachers from PDDRTeachers experiment. """
+        _, _, extra = load_experiment(exp)
+        self.unpack_teachers(extra)
+
+    def unpack_teachers(self, extra):
+        """ Unpack teachers from PDDRTeachers experiment. """
+        self.teacher_policies.extend(extra["teacher_policies"])
+        self.teacher_envs.extend(extra["teacher_envs"])
+        self.teacher_expl_strats.extend(extra["teacher_expl_strats"])
+        self.teacher_critics.extend(extra["teacher_critics"])
+        self.teacher_ex_dirs.extend(extra["teacher_ex_dirs"])
+
+    def prune_teachers(self):
+        """ Prune teachers to only use the first num_teachers of them. """
+        self.teacher_policies = self.teacher_policies[: self.num_teachers]
+        self.teacher_envs = self.teacher_envs[: self.num_teachers]
+        self.teacher_expl_strats = self.teacher_expl_strats[: self.num_teachers]
+        self.teacher_critics = self.teacher_critics[: self.num_teachers]
+        self.teacher_ex_dirs = self.teacher_ex_dirs[: self.num_teachers]

--- a/Pyrado/pyrado/algorithms/meta/pddr.py
+++ b/Pyrado/pyrado/algorithms/meta/pddr.py
@@ -191,7 +191,7 @@ class PDDR(InterruptableAlgorithm):
 
     def step(self, snapshot_mode: str, meta_info: dict = None):
         """
-        Perform a single iteration of the algorithm. This includes collecting the data, updating the parameters, and
+        Performs a single iteration of the algorithm. This includes collecting the data, updating the parameters, and
         adding the metrics of interest to the logger. Does not update the `curr_iter` attribute.
 
         :param snapshot_mode: determines when the snapshots are stored (e.g. on every iteration or on new highscore)
@@ -228,6 +228,7 @@ class PDDR(InterruptableAlgorithm):
     def sample(self) -> Tuple[List[List[StepSequence]], np.array, np.array]:
         """
         Samples observations from several samplers.
+
         :return: list of rollouts per sampler, list of all returns, list of all rollout lengths
         """
         ros = []
@@ -279,6 +280,7 @@ class PDDR(InterruptableAlgorithm):
     def _train_teacher(self, idx: int, snapshot_mode: str = "latest", seed: int = None):
         """
         Wrapper for use of multiprocessing: Trains one teacher.
+
         :param idx: index of the teacher to be trained
         :param snapshot_mode: determines when the snapshots are stored (e.g. on every iteration or on new high-score)
         :param seed: seed value for the random number generators, pass `None` for no seeding
@@ -298,6 +300,7 @@ class PDDR(InterruptableAlgorithm):
     def train_teachers(self, snapshot_mode: str = "latest", seed: int = None):
         """
         Trains all teachers.
+
         :param snapshot_mode: determines when the snapshots are stored (e.g. on every iteration or on new high-score)
         :param seed: seed value for the random number generators, pass `None` for no seeding
         """
@@ -323,6 +326,7 @@ class PDDR(InterruptableAlgorithm):
     def load_teacher_experiment(self, exp: Experiment):
         """
         Load teachers from PDDRTeachers experiment.
+        
         :param exp: the teacher's experiment object
         """
         _, _, extra = load_experiment(exp)
@@ -331,6 +335,7 @@ class PDDR(InterruptableAlgorithm):
     def unpack_teachers(self, extra: dict):
         """
         Unpack teachers from PDDRTeachers experiment.
+
         :param extra: dict with teacher data
         """
         self.teacher_policies.extend(extra["teacher_policies"])

--- a/Pyrado/pyrado/logger/experiment.py
+++ b/Pyrado/pyrado/logger/experiment.py
@@ -212,9 +212,11 @@ def list_experiments(
 ):
     """
     List all stored experiments.
+
     :param env_name: filter by env name
     :param algo_name: filter by algorithm name. Requires env_name to be used too
-    :param base_dir: explicit base dir if desired. May also be a list of bases. Uses temp and perm dir if not specified.
+    :param base_dir: explicit base dir if desired. May also be a list of bases.
+                     Uses `pyrado.TEMP_DIR` and `pyrado.EXP_DIR` if not specified.
     :param temp: set to `False` to not look in the `pyrado.TEMP` directory
     :param perma: set to `False` to not look in the `pyrado.PERMA` directory
     """
@@ -366,6 +368,7 @@ def ask_for_experiment(
 ) -> Experiment:
     """
     Ask for an experiment on the console. This is the go-to entry point for evaluation scripts.
+
     :param latest_only: only select the latest experiment of each type (environment-algorithm combination)
     :param max_display: maximum number of items
     :param env_name: filter by env name

--- a/Pyrado/pyrado/logger/experiment.py
+++ b/Pyrado/pyrado/logger/experiment.py
@@ -212,7 +212,6 @@ def list_experiments(
 ):
     """
     List all stored experiments.
-
     :param env_name: filter by env name
     :param algo_name: filter by algorithm name. Requires env_name to be used too
     :param base_dir: explicit base dir if desired. May also be a list of bases. Uses temp and perm dir if not specified.
@@ -358,19 +357,26 @@ def split_path_custom_common(path: Union[str, Experiment]) -> (str, str):
 
 
 def ask_for_experiment(
-    latest_only: bool = False, max_display: int = 10, hparam_list: Optional[List[str]] = None
+    latest_only: bool = False,
+    max_display: int = 10,
+    env_name: str = None,
+    temp: bool = True,
+    perma: bool = True,
+    hparam_list: Optional[List[str]] = None,
 ) -> Experiment:
     """
     Ask for an experiment on the console. This is the go-to entry point for evaluation scripts.
-
     :param latest_only: only select the latest experiment of each type (environment-algorithm combination)
-    :param max_display: only display this many items
+    :param max_display: maximum number of items
+    :param env_name: filter by env name
+    :param temp: set to `False` to not look in the `pyrado.TEMP` directory
+    :param perma: set to `False` to not look in the `pyrado.PERMA` directory
     :param hparam_list: load the hyper-parameter file and show the parameters in this list,
                         sub-dicts can be separated with a dot
     :return: query asking the user for an experiment
     """
     # Scan for experiment list
-    all_exps = list(list_experiments())
+    all_exps = list(list_experiments(env_name=env_name, perma=perma, temp=temp))
 
     if len(all_exps) == 0:
         print_cbt("No experiments found!", "r")

--- a/Pyrado/pyrado/policies/recurrent/rnn.py
+++ b/Pyrado/pyrado/policies/recurrent/rnn.py
@@ -156,38 +156,62 @@ class RNNPolicyBase(RecurrentPolicy):
         # Set policy, i.e. PyTorch nn.Module, to evaluation mode
         self.eval()
 
-        # The passed sample collection might contain multiple rollouts.
-        # Note:
-        # While we *could* try to convert this to a PackedSequence, allowing us to only call the network once, that
-        # would require a lot of reshaping on the result. So let's not. If performance becomes an issue, revisit here.
-        act_list = []
+        # Get a list of all observation sequences and their respective lengths
+        obs_list = []
+        lengths = []
+        hidden_list = []
+
         for ro in rollout.iterate_rollouts():
             if hidden_states_name in rollout.data_names:
-                # Get initial hidden state from first step
-                hidden = self._unpack_hidden(ro[0][hidden_states_name])
+                # Get initial hidden state from first step, but do not unpack it yet
+                hidden_list.append(ro[0][hidden_states_name])
             else:
-                # Let the network pick the default hidden state
-                hidden = None
+                # If no hidden state is given, let it be None
+                hidden_list.append(None)
 
             # Reshape observations to match PyTorch's RNN sequence protocol
-            obs = ro.get_data_values("observations", True).unsqueeze(1)
+            obs = ro.get_data_values("observations", True)
             obs = obs.to(device=self.device, dtype=to.get_default_dtype())
 
-            # Pass the input through hidden RNN layers
-            out, _ = self.rnn_layers(obs, hidden)
+            # Get all observation sequences and their respective lengths
+            obs_list.append(obs)
+            lengths.append(len(obs))
 
-            # And through the output layer
-            act = self.output_layer(out.squeeze(1))
-            if self.output_nonlin is not None:
-                act = self.output_nonlin(act)
+        # Pad and then pack observations
+        obs_padded = to.nn.utils.rnn.pad_sequence(obs_list)
+        obs_packed = to.nn.utils.rnn.pack_padded_sequence(obs_padded, lengths=lengths, enforce_sorted=False)
 
-            # Collect the actions
-            act_list.append(act)
+        # Check whether no hidden state was provided
+        if all(h is None for h in hidden_list):
+            hidden = None
+        else:
+            # Get dimension of hidden state, by using first not None element of hidden state list
+            dim_hidden = next(h for h in hidden_list if h is not None).shape
+
+            # Exchange all Nones through zero tensors (Pytorch default)
+            hidden_list = [to.zeros(dim_hidden) if h is None else h for h in hidden_list]
+
+            # Get hidden state
+            batch_size = len(hidden_list)
+            hidden = to.stack(hidden_list, 0)
+            hidden = self._unpack_hidden(hidden, batch_size=batch_size)
+
+        # Pass packed observation through RNN, result is also packed
+        out_packed, _ = self.rnn_layers(obs_packed, hidden)
+
+        # Unpack result
+        out, lens = to.nn.utils.rnn.pad_packed_sequence(out_packed)
+        out = to.cat([out[:l, i] for i, l in enumerate(lens)], 0)
+
+        # Then pass all of it through the output layer
+        act = self.output_layer(out)
+        if self.output_nonlin is not None:
+            act = self.output_nonlin(act)
 
         # Set policy, i.e. PyTorch nn.Module, back to training mode
         self.train()
 
-        return to.cat(act_list)
+        return act
 
     def _unpack_hidden(self, hidden: to.Tensor, batch_size: int = None):
         """

--- a/Pyrado/pyrado/utils/argparser.py
+++ b/Pyrado/pyrado/utils/argparser.py
@@ -266,6 +266,9 @@ def get_argparser() -> argparse.ArgumentParser:
         action="append",
         help="hyperparameters to show in the ask-for-experiment dialog; use this parameter multiple times to show multiple hyperparameters; e.g. to differentiate between experiments",
     )
+    parser.add_argument(
+        "--device", type=str, default="cpu", help="device (either 'cpu' or 'cuda') to use for PyTorch (default: 'cpu')"
+    )
 
     segment_group = parser.add_mutually_exclusive_group(required=False)
     segment_group.add_argument(

--- a/Pyrado/pyrado/utils/experiments.py
+++ b/Pyrado/pyrado/utils/experiments.py
@@ -220,6 +220,19 @@ def load_experiment(
         if isinstance(algo._subroutine, ActorCritic):
             extra["vfcn"] = pyrado.load(algo._subroutine.critic.vfcn, f"{args.vfcn_name}", "pt", ex_dir, None)
             print_cbt(f"Loaded {osp.join(ex_dir, f'{args.vfcn_name}.pt')}", "g")
+
+    elif algo.name == "pddr":
+        # Environment
+        env = pyrado.load("env.pkl", ex_dir)
+        # Policy
+        policy = pyrado.load(f"{args.policy_name}.pt", ex_dir, obj=algo.policy, verbose=True)
+        # Teachers
+        extra["teacher_policies"] = algo.teacher_policies
+        extra["teacher_envs"] = algo.teacher_envs
+        extra["teacher_expl_strats"] = algo.teacher_expl_strats
+        extra["teacher_critics"] = algo.teacher_critics
+        extra["teacher_ex_dirs"] = algo.teacher_ex_dirs
+
     else:
         raise pyrado.TypeErr(msg="No matching algorithm name found during loading the experiment!")
 

--- a/Pyrado/scripts/training/qq-su_pddr.py
+++ b/Pyrado/scripts/training/qq-su_pddr.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     ex_dir = setup_experiment(QQubeSwingUpSim.name, f"{PDDR.name}_{QQubeSwingUpAndBalanceCtrl.name}{descr}")
 
     if args.train_teachers:
-        # Policy
+        # Teacher policy
         teacher_policy_hparam = dict(
             hidden_sizes=[64, 64], hidden_nonlin=to.relu, output_nonlin=to.tanh, use_cuda=use_cuda
         )
@@ -85,7 +85,7 @@ if __name__ == "__main__":
             with to.no_grad():
                 p /= 100
 
-        # Critic
+        # Teacher critic
         vfcn_hparam = dict(hidden_sizes=[32, 32], hidden_nonlin=to.relu)
         vfcn = FNNPolicy(spec=EnvSpec(env_real.obs_space, ValueFunctionSpace), **vfcn_hparam)
         critic_hparam = dict(
@@ -101,7 +101,7 @@ if __name__ == "__main__":
         )
         critic = GAE(vfcn, **critic_hparam)
 
-        # Subroutine
+        # Teacher subroutine
         teacher_algo_hparam = dict(
             eps_clip=0.12648736789309026,
             min_steps=env_real.max_steps,

--- a/Pyrado/scripts/training/qq-su_pddr.py
+++ b/Pyrado/scripts/training/qq-su_pddr.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2020, Fabio Muratore, Honda Research Institute Europe GmbH, and
+# Technical University of Darmstadt.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of Fabio Muratore, Honda Research Institute Europe GmbH,
+#    or Technical University of Darmstadt, nor the names of its contributors may
+#    be used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL FABIO MURATORE, HONDA RESEARCH INSTITUTE EUROPE GMBH,
+# OR TECHNICAL UNIVERSITY OF DARMSTADT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Train an agent to solve the Quanser Qube swing-up task using Policy Distillation with Domain Randomization.
+
+.. note::
+    Call with defining --max_steps.
+"""
+import torch as to
+from torch.optim import lr_scheduler
+
+import pyrado
+from pyrado.algorithms.meta.pddr import PDDR
+from pyrado.algorithms.step_based.gae import GAE
+from pyrado.algorithms.step_based.ppo import PPO
+from pyrado.domain_randomization.default_randomizers import create_default_randomizer
+from pyrado.environment_wrappers.action_normalization import ActNormWrapper
+from pyrado.environment_wrappers.domain_randomization import DomainRandWrapperLive
+from pyrado.environments.pysim.quanser_qube import QQubeSwingUpSim
+from pyrado.logger.experiment import save_dicts_to_yaml, setup_experiment
+from pyrado.policies.feed_forward.fnn import FNNPolicy
+from pyrado.policies.special.environment_specific import QQubeSwingUpAndBalanceCtrl
+from pyrado.spaces import ValueFunctionSpace
+from pyrado.utils.argparser import get_argparser
+from pyrado.utils.data_types import EnvSpec
+
+
+if __name__ == "__main__":
+    parser = get_argparser()
+    parser.add_argument("--freq", type=int, default=250)
+    parser.add_argument("--max_iter_teacher", type=int, default=200)
+    parser.add_argument("--train_teachers", action="store_true", default=False)
+    parser.add_argument("--num_teachers", type=int, default=2)
+    parser.add_argument("--max_iter", type=int, default=500)
+    parser.add_argument("--num_epochs", type=int, default=10)
+
+    # Parse command line arguments
+    args = parser.parse_args()
+
+    # Set seed if desired
+    pyrado.set_seed(args.seed, verbose=True)
+    use_cuda = args.device == "cuda"
+    descr = f"_{args.max_steps}st_{args.freq}Hz"
+
+    # Environment
+    env_hparams = dict(dt=1 / args.freq, max_steps=args.max_steps)
+    env_real = QQubeSwingUpSim(**env_hparams)
+    ex_dir = setup_experiment(QQubeSwingUpSim.name, f"{PDDR.name}_{QQubeSwingUpAndBalanceCtrl.name}{descr}")
+
+    if args.train_teachers:
+        # Policy
+        teacher_policy_hparam = dict(
+            hidden_sizes=[64, 64], hidden_nonlin=to.relu, output_nonlin=to.tanh, use_cuda=use_cuda
+        )
+        teacher_policy = FNNPolicy(spec=env_real.spec, **teacher_policy_hparam)
+
+        # Reduce weights of last layer, recommended by paper
+        for p in teacher_policy.net.output_layer.parameters():
+            with to.no_grad():
+                p /= 100
+
+        # Critic
+        vfcn_hparam = dict(hidden_sizes=[32, 32], hidden_nonlin=to.relu)
+        vfcn = FNNPolicy(spec=EnvSpec(env_real.obs_space, ValueFunctionSpace), **vfcn_hparam)
+        critic_hparam = dict(
+            gamma=0.9844224855479998,
+            lamda=0.9700148505302241,
+            num_epoch=5,
+            batch_size=500,
+            standardize_adv=False,
+            lr=7.058326426522811e-4,
+            max_grad_norm=6.0,
+            lr_scheduler=lr_scheduler.ExponentialLR,
+            lr_scheduler_hparam=dict(gamma=0.999),
+        )
+        critic = GAE(vfcn, **critic_hparam)
+
+        # Subroutine
+        teacher_algo_hparam = dict(
+            eps_clip=0.12648736789309026,
+            min_steps=env_real.max_steps,
+            num_epoch=7,
+            batch_size=500,
+            std_init=0.7573286998997557,
+            lr=6.999956625305722e-04,
+            max_grad_norm=1.0,
+            num_workers=8,
+            lr_scheduler=lr_scheduler.ExponentialLR,
+            lr_scheduler_hparam=dict(gamma=0.999),
+            max_iter=args.max_iter_teacher,
+            critic=critic,
+        )
+
+        teacher_algo = PPO
+
+    else:
+        teacher_policy = None
+        teacher_algo = None
+        teacher_algo_hparam = None
+
+    # Wrapper
+    randomizer = create_default_randomizer(env_real)
+    env_real = DomainRandWrapperLive(env_real, randomizer)
+    env_real = ActNormWrapper(env_real)
+
+    # Policy
+    policy_hparam = dict(hidden_sizes=[64, 64], hidden_nonlin=to.relu, output_nonlin=to.tanh)
+    policy = FNNPolicy(spec=env_real.spec, **policy_hparam)
+
+    # Subroutine
+    algo_hparam = dict(
+        max_iter=args.max_iter,
+        min_steps=args.max_steps,
+        num_cpu=12,
+        std_init=0.15,
+        num_epochs=args.num_epochs,
+        num_teachers=args.num_teachers,
+        teacher_policy=teacher_policy,
+        teacher_algo=teacher_algo,
+        teacher_algo_hparam=teacher_algo_hparam,
+    )
+
+    algo = PDDR(ex_dir, env_real, policy, **algo_hparam)
+
+    # Save the hyper-parameters
+    save_dicts_to_yaml(
+        dict(env=env_hparams, seed=args.seed),
+        dict(policy=policy_hparam),
+        dict(algo=algo_hparam, algo_name=algo.name),
+        save_dir=ex_dir,
+    )
+
+    # Jeeeha
+    algo.train(snapshot_mode="best", seed=args.seed)

--- a/Pyrado/tests/algorithms/test_meta.py
+++ b/Pyrado/tests/algorithms/test_meta.py
@@ -752,7 +752,7 @@ def test_pddr(ex_dir, env: SimEnv, policy, algo_hparam):
 
     # Subroutine
     algo_hparam = dict(
-        max_iter=10,
+        max_iter=2,
         min_steps=env.max_steps,
         num_cpu=2,
         std_init=0.15,

--- a/Pyrado/tests/test_policies.py
+++ b/Pyrado/tests/test_policies.py
@@ -39,7 +39,7 @@ from pyrado.policies.feed_back.dual_rfb import DualRBFLinearPolicy
 from pyrado.policies.feed_back.linear import LinearPolicy
 from pyrado.policies.feed_forward.playback import PlaybackPolicy
 from pyrado.policies.feed_forward.poly_time import PolySplineTimePolicy
-from pyrado.policies.recurrent.base import default_pack_hidden, default_unpack_hidden
+from pyrado.policies.recurrent.base import RecurrentPolicy, default_pack_hidden, default_unpack_hidden
 from pyrado.policies.recurrent.two_headed_rnn import TwoHeadedRNNPolicyBase
 from pyrado.sampling.rollout import rollout
 from pyrado.sampling.step_sequence import StepSequence


### PR DESCRIPTION
This pull request consists of:

- An implementation of Policy Distillation with Domain Randomization (PDDR)
- Improvement of the RNN evaluate function with the use of packed padded sequences
     - The speedup compared to the old implementation is dependent on the number and other propetries of the rollouts
     - For small rollout numbers (e.g. 10) we get a speedup of 50-60% and for larger rollout numbers (1000), a speedup of about 300-400%. However, take these numbers with a grain of salt, since there are even more factors that can influence this comparison
     - We added a test that compares the new and old implementation
