### PR TITLE
Add a wrapper for the subroutine rollouts

### DIFF
--- a/Pyrado/pyrado/algorithms/meta/sprl.py
+++ b/Pyrado/pyrado/algorithms/meta/sprl.py
@@ -316,7 +316,7 @@ class SPRL(Algorithm):
         super().__init__(subroutine.save_dir, max_iter, subroutine.policy, subroutine.logger)
 
         # Wrap the sampler of the subroutine with an rollout saving wrapper
-        ros = RolloutSavingWrapper(sampler=subroutine.sampler)
+        ros = RolloutSavingWrapper(subroutine.sampler)
         subroutine.sampler = ros
 
         # Using a Union here is not really correct, but it makes PyCharm's type hinting work

--- a/Pyrado/pyrado/algorithms/meta/sprl.py
+++ b/Pyrado/pyrado/algorithms/meta/sprl.py
@@ -559,14 +559,13 @@ class SPRL(Algorithm):
             else:
                 print(f"Update unsuccessful, keeping old values spl parameters")
 
-        self._subroutine.sampler.reset_rollouts()
-
     def reset(self, seed: int = None):
         # Forward to subroutine
         self._subroutine.reset(seed)
         self._subroutine.sampler.reset_rollouts()
 
     def save_snapshot(self, meta_info: dict = None):
+        self._subroutine.sampler.reset_rollouts()
         super().save_snapshot(meta_info)
 
         if meta_info is None:

--- a/Pyrado/pyrado/algorithms/meta/sprl.py
+++ b/Pyrado/pyrado/algorithms/meta/sprl.py
@@ -266,6 +266,9 @@ class RolloutSavingWrapper:
         self.rollouts.append(sample)
         return sample
 
+    def reset_rollouts(self) -> None:
+        self.rollouts = []
+
     def __getattr__(self, name: str) -> Any:
         return getattr(self.sampler, name)
 
@@ -556,9 +559,12 @@ class SPRL(Algorithm):
             else:
                 print(f"Update unsuccessful, keeping old values spl parameters")
 
+        self._subroutine.sampler.reset_rollouts()
+
     def reset(self, seed: int = None):
         # Forward to subroutine
         self._subroutine.reset(seed)
+        self._subroutine.sampler.reset_rollouts()
 
     def save_snapshot(self, meta_info: dict = None):
         super().save_snapshot(meta_info)

--- a/Pyrado/pyrado/algorithms/utils.py
+++ b/Pyrado/pyrado/algorithms/utils.py
@@ -240,14 +240,10 @@ def get_grad_via_torch(x_np: np.ndarray, fcn_to: Callable, *args_to, **kwargs_to
 @dataclass
 class RolloutSavingWrapper:
     """
-    A wrapper for :py:class:`pyrado.sampling.sampler.SamplerBase` objects.
-    Calls to :py:meth:`pyrado.sampling.sampler.SamplerBase.sample` are intercepted
-    and the results saved before they are returned to the callee.
-    All other calls to attributes and methods are forwarded to the sampler
-    object.
+    A wrapper for `SamplerBase` objects where calls to `SamplerBase.sample()` are intercepted and the results stored 
+    in this wrapper before they are returned to the caller.
 
-    **Usage**:
-
+    :usage:
     .. code-block:: python
 
         ros = RolloutSavingWrapper(sampler=subroutine.sampler)
@@ -258,19 +254,18 @@ class RolloutSavingWrapper:
     rollouts: List[List[StepSequence]] = field(default_factory=list)
 
     def sample(self, *args, **kwargs) -> List[StepSequence]:
-        """Like :py:meth:`pyrado.sampling.sampler.SamplerBase.sample()`
-        but keeps a copy of all returned values.
-
-        """
+        """Like `SamplerBase.sample()` but keeps a copy of all returned values."""
         sample = self.sampler.sample(*args, **kwargs)
         self.rollouts.append(sample)
         return sample
 
     def reset_rollouts(self) -> None:
-        """Resets the internal rollout variable, ideally
-        called before `save_snapshot()` to reduce serialized object size.
+        """
+        Resets the internal rollout variable. Inteded to be called before `save_snapshot()`, in order to
+        reduce serialized object's size.
         """
         self.rollouts = []
 
     def __getattr__(self, name: str) -> Any:
+        # Forward to the wrapped sampler
         return getattr(self.sampler, name)

--- a/Pyrado/pyrado/algorithms/utils.py
+++ b/Pyrado/pyrado/algorithms/utils.py
@@ -240,22 +240,22 @@ def get_grad_via_torch(x_np: np.ndarray, fcn_to: Callable, *args_to, **kwargs_to
 @dataclass
 class RolloutSavingWrapper:
     """
-    A wrapper for `SamplerBase` objects where calls to `SamplerBase.sample()` are intercepted and the results stored 
+    A wrapper for `SamplerBase` objects where calls to `SamplerBase.sample()` are intercepted and the results stored
     in this wrapper before they are returned to the caller.
 
     :usage:
     .. code-block:: python
 
-        ros = RolloutSavingWrapper(sampler=subroutine.sampler)
+        ros = RolloutSavingWrapper(subroutine.sampler)
         subroutine.sampler = ros
     """
 
-    sampler: SamplerBase
+    wrapped_sampler: SamplerBase
     rollouts: List[List[StepSequence]] = field(default_factory=list)
 
     def sample(self, *args, **kwargs) -> List[StepSequence]:
         """Like `SamplerBase.sample()` but keeps a copy of all returned values."""
-        sample = self.sampler.sample(*args, **kwargs)
+        sample = self.wrapped_sampler.sample(*args, **kwargs)
         self.rollouts.append(sample)
         return sample
 
@@ -268,4 +268,4 @@ class RolloutSavingWrapper:
 
     def __getattr__(self, name: str) -> Any:
         # Forward to the wrapped sampler
-        return getattr(self.sampler, name)
+        return getattr(self.wrapped_sampler, name)


### PR DESCRIPTION
It intercepts calls to `sample()` and saves the result before returning it. This should fix the performance regression introduced during the refactoring.