### PR TITLE
Fixed that sampling hangs for large neural networks policies.

### DIFF
--- a/Pyrado/pyrado/policies/recurrent/neural_fields.py
+++ b/Pyrado/pyrado/policies/recurrent/neural_fields.py
@@ -107,7 +107,7 @@ class NFPolicy(PotentialBasedPolicy):
             raise pyrado.TypeErr(given=activation_nonlin, expected_type=Callable)
 
         # Set the multiprocessing start method to spawn, since PyTorch is using the GPU for convolutions if it can
-        if to.cuda.is_available() and mp.get_start_method(allow_none=True) != "spawn":
+        if mp.get_start_method(allow_none=True) != "spawn":
             mp.set_start_method("spawn", force=True)
 
         super().__init__(

--- a/Pyrado/pyrado/sampling/parallel_rollout_sampler.py
+++ b/Pyrado/pyrado/sampling/parallel_rollout_sampler.py
@@ -183,7 +183,7 @@ class ParallelRolloutSampler(SamplerBase, Serializable):
         self.show_progress_bar = show_progress_bar
 
         # Set method to spawn if using cuda
-        if self.policy.device != "cpu" and mp.get_start_method(allow_none=True) != "spawn":
+        if mp.get_start_method(allow_none=True) != "spawn":
             mp.set_start_method("spawn", force=True)
 
         # Create parallel pool. We use one thread per env because it's easier.

--- a/Pyrado/pyrado/sampling/parameter_exploration_sampler.py
+++ b/Pyrado/pyrado/sampling/parameter_exploration_sampler.py
@@ -186,7 +186,7 @@ class ParameterExplorationSampler(Serializable):
         self.num_domains = num_domains
 
         # Set method to spawn if using cuda
-        if self.policy.device != "cpu" and mp.get_start_method(allow_none=True) != "spawn":
+        if mp.get_start_method(allow_none=True) != "spawn":
             mp.set_start_method("spawn", force=True)
 
         # Create parallel pool. We use one thread per environment because it's easier.


### PR DESCRIPTION
Try running
```python
env = RosenSim()
policy = FNNPolicy(spec=env.spec, hidden_sizes=[128, 128], hidden_nonlin=to.relu)
sampler = ParallelRolloutSampler(env, policy, num_workers=2, min_steps=1)
sampler.sample()
```
with and without this PR. Without, sampling hangs (probably) indefinitely.