### PR TITLE
Include `SLURM_ARRAY_JOB_ID` in extra info instead of `SLURM_JOB_ID`.

### DIFF
--- a/Pyrado/pyrado/logger/experiment.py
+++ b/Pyrado/pyrado/logger/experiment.py
@@ -79,8 +79,8 @@ class Experiment:
         """
 
         slurm_id = None
-        if include_slurm_id and "SLURM_JOB_ID" in os.environ:
-            slurm_id = str(os.environ["SLURM_JOB_ID"])
+        if include_slurm_id and "SLURM_ARRAY_JOB_ID" in os.environ:
+            slurm_id = str(os.environ["SLURM_ARRAY_JOB_ID"])
             if "SLURM_ARRAY_TASK_ID" in os.environ:
                 slurm_id += "_" + str(os.environ["SLURM_ARRAY_TASK_ID"])
         if exp_id is None:

--- a/remotelaunch/slurm_launcher_cpu.sh
+++ b/remotelaunch/slurm_launcher_cpu.sh
@@ -44,7 +44,7 @@
 ###############################################################################
 
 # Your program call starts here
-echo "Starting Job $SLURM_JOB_ID, Index $SLURM_ARRAY_TASK_ID"
+echo "Starting Job $SLURM_JOB_ID, Array Job $SLURM_ARRAY_JOB_ID Index $SLURM_ARRAY_TASK_ID"
 
 # Activate the pyrado anaconda environment
 eval "$($HOME/Software/anaconda3/bin/conda shell.bash hook)"

--- a/remotelaunch/slurm_launcher_gpu.sh
+++ b/remotelaunch/slurm_launcher_gpu.sh
@@ -44,7 +44,7 @@
 ###############################################################################
 
 # Your program call starts here
-echo "Starting Job $SLURM_JOB_ID, Index $SLURM_ARRAY_TASK_ID"
+echo "Starting Job $SLURM_JOB_ID, Array Job $SLURM_ARRAY_JOB_ID Index $SLURM_ARRAY_TASK_ID"
 
 # Activate the pyrado anaconda environment
 eval "$($HOME/Software/anaconda3/bin/conda shell.bash hook)"

--- a/remotelaunch/slurm_launcher_hparam_array.sh
+++ b/remotelaunch/slurm_launcher_hparam_array.sh
@@ -44,7 +44,7 @@
 ###############################################################################
 
 # Your program call starts here
-echo "Starting Job $SLURM_JOB_ID, Index $SLURM_ARRAY_TASK_ID"
+echo "Starting Job $SLURM_JOB_ID, Array Job $SLURM_ARRAY_JOB_ID Index $SLURM_ARRAY_TASK_ID"
 
 # Activate the pyrado anaconda environment
 eval "$($HOME/Software/anaconda3/bin/conda shell.bash hook)"

--- a/remotelaunch/slurm_launcher_seed_array.sh
+++ b/remotelaunch/slurm_launcher_seed_array.sh
@@ -44,7 +44,7 @@
 ###############################################################################
 
 # Your program call starts here
-echo "Starting Job $SLURM_JOB_ID, Index $SLURM_ARRAY_TASK_ID"
+echo "Starting Job $SLURM_JOB_ID, Array Job $SLURM_ARRAY_JOB_ID Index $SLURM_ARRAY_TASK_ID"
 
 # Activate the pyrado anaconda environment
 eval "$($HOME/Software/anaconda3/bin/conda shell.bash hook)"


### PR DESCRIPTION
The `SLURM_JOB_ID` is unique for every job, while the `SLURM_ARRAY_JOB_ID` is shown in `squeue`, combined with the `SLURM_ARRAY_TASK_ID`.