### PR TITLE
New nn init copied from pytorch 1.8

### DIFF
--- a/Pyrado/pyrado/policies/initialization.py
+++ b/Pyrado/pyrado/policies/initialization.py
@@ -66,56 +66,64 @@ def init_param(m, **kwargs):
         else:
             init.normal_(m.data)
 
-    elif isinstance(m, (nn.Linear, nn.RNN, nn.GRU, nn.GRUCell)):
+    elif isinstance(m, nn.Linear):
         for name, param in m.named_parameters():
             if "weight" in name:
                 if param.ndim >= 2:
                     # Most common case
-                    init.orthogonal_(param.data)  # former: init.xavier_normal_(param.data)
+                    init.kaiming_uniform_(param.data, a=sqrt(5))
                 else:
                     init.normal_(param.data)
             elif "bias" in name:
-                if kwargs.get("uniform_bias", False):
-                    init.uniform_(param.data, a=-1.0 / sqrt(param.data.nelement()), b=1.0 / sqrt(param.data.nelement()))
-                else:
-                    # Default case
-                    init.normal_(param.data, std=1.0 / sqrt(param.data.nelement()))
+                fan_in, _ = init._calculate_fan_in_and_fan_out(param.data)
+                bound = 1 / sqrt(fan_in) if fan_in > 0 else 0
+                init.uniform_(param.data, -bound, bound)
             else:
                 raise pyrado.KeyErr(keys="weight or bias", container=param)
 
+    elif isinstance(m, (nn.RNN, nn.GRU, nn.GRUCell)):
+        stdv = 1.0 / sqrt(m.hidden_size)
+        for name, param in m.named_parameters():
+            init.uniform_(param, -stdv, stdv)
+
     elif isinstance(m, (nn.LSTM, nn.LSTMCell)):
         for name, param in m.named_parameters():
-            if "weight_ih" in name:
-                # Initialize the input to hidden weights orthogonally
-                # w_ii, w_if, w_ic, w_io
-                nn.init.orthogonal_(param.data)
-            elif "weight_hh" in name:
-                # Initialize the hidden to hidden weights separately as identity matrices and stack them afterwards
-                # w_ii, w_if, w_ic, w_io
-                weight_hh_ii = to.eye(m.hidden_size, m.hidden_size)
-                weight_hh_if = to.eye(m.hidden_size, m.hidden_size)
-                weight_hh_ic = to.eye(m.hidden_size, m.hidden_size)
-                weight_hh_io = to.eye(m.hidden_size, m.hidden_size)
-                weight_hh_all = to.cat([weight_hh_ii, weight_hh_if, weight_hh_ic, weight_hh_io], dim=0)
-                param.data.copy_(weight_hh_all)
-            elif "bias" in name:
-                # b_ii, b_if, b_ig, b_io
-                if "t_max" in kwargs:
-                    assert isinstance(kwargs["t_max"], (float, int, to.Tensor)), pyrado.TypeErr(
-                        given=kwargs["t_max"], expected_type=[float, int, to.Tensor]
-                    )
-                    # Initialize all biases to 0, but the bias of the forget and input gate using the chrono init
-                    nn.init.constant_(param.data, val=0)
-                    param.data[m.hidden_size : m.hidden_size * 2] = to.log(
-                        nn.init.uniform_(  # forget gate
-                            param.data[m.hidden_size : m.hidden_size * 2], 1, kwargs["t_max"] - 1
+            if "t_max" in kwargs:
+                if "weight_ih" in name:
+                    # Initialize the input to hidden weights orthogonally
+                    # w_ii, w_if, w_ic, w_io
+                    nn.init.orthogonal_(param.data)
+                elif "weight_hh" in name:
+                    # Initialize the hidden to hidden weights separately as identity matrices and stack them afterwards
+                    # w_ii, w_if, w_ic, w_io
+                    weight_hh_ii = to.eye(m.hidden_size, m.hidden_size)
+                    weight_hh_if = to.eye(m.hidden_size, m.hidden_size)
+                    weight_hh_ic = to.eye(m.hidden_size, m.hidden_size)
+                    weight_hh_io = to.eye(m.hidden_size, m.hidden_size)
+                    weight_hh_all = to.cat([weight_hh_ii, weight_hh_if, weight_hh_ic, weight_hh_io], dim=0)
+                    param.data.copy_(weight_hh_all)
+                elif "bias" in name:
+                    # b_ii, b_if, b_ig, b_io
+                    if "t_max" in kwargs:
+                        assert isinstance(kwargs["t_max"], (float, int, to.Tensor)), pyrado.TypeErr(
+                            given=kwargs["t_max"], expected_type=[float, int, to.Tensor]
                         )
-                    )
-                    param.data[0 : m.hidden_size] = -param.data[m.hidden_size : 2 * m.hidden_size]  # input gate
-                else:
-                    # Initialize all biases to 0, but the bias of the forget gate to 1
-                    nn.init.constant_(param.data, val=0)
-                    param.data[m.hidden_size : m.hidden_size * 2].fill_(1)
+                        # Initialize all biases to 0, but the bias of the forget and input gate using the chrono init
+                        nn.init.constant_(param.data, val=0)
+                        param.data[m.hidden_size : m.hidden_size * 2] = to.log(
+                            nn.init.uniform_(  # forget gate
+                                param.data[m.hidden_size : m.hidden_size * 2], 1, kwargs["t_max"] - 1
+                            )
+                        )
+                        param.data[0 : m.hidden_size] = -param.data[m.hidden_size : 2 * m.hidden_size]  # input gate
+                    else:
+                        # Initialize all biases to 0, but the bias of the forget gate to 1
+                        nn.init.constant_(param.data, val=0)
+                        param.data[m.hidden_size : m.hidden_size * 2].fill_(1)
+            else:
+                stdv = 1.0 / sqrt(m.hidden_size)
+                for name, param in m.named_parameters():
+                    init.uniform_(param, -stdv, stdv)
 
     elif isinstance(m, nn.Conv1d):
         if kwargs.get("bell", False):

--- a/Pyrado/pyrado/policies/initialization.py
+++ b/Pyrado/pyrado/policies/initialization.py
@@ -67,6 +67,7 @@ def init_param(m, **kwargs):
             init.normal_(m.data)
 
     elif isinstance(m, nn.Linear):
+        # PyToch's default initalization
         for name, param in m.named_parameters():
             if "weight" in name:
                 if param.ndim >= 2:
@@ -82,6 +83,7 @@ def init_param(m, **kwargs):
                 raise pyrado.KeyErr(keys="weight or bias", container=param)
 
     elif isinstance(m, (nn.RNN, nn.GRU, nn.GRUCell)):
+        # PyToch's default initalization
         stdv = 1.0 / sqrt(m.hidden_size)
         for name, param in m.named_parameters():
             init.uniform_(param, -stdv, stdv)
@@ -89,6 +91,7 @@ def init_param(m, **kwargs):
     elif isinstance(m, (nn.LSTM, nn.LSTMCell)):
         for name, param in m.named_parameters():
             if "t_max" in kwargs:
+                # Custom initialization (see [2])
                 if "weight_ih" in name:
                     # Initialize the input to hidden weights orthogonally
                     # w_ii, w_if, w_ic, w_io
@@ -121,6 +124,7 @@ def init_param(m, **kwargs):
                         nn.init.constant_(param.data, val=0)
                         param.data[m.hidden_size : m.hidden_size * 2].fill_(1)
             else:
+                # PyToch's default initalization
                 stdv = 1.0 / sqrt(m.hidden_size)
                 for name, param in m.named_parameters():
                     init.uniform_(param, -stdv, stdv)

--- a/Pyrado/pyrado/policies/initialization.py
+++ b/Pyrado/pyrado/policies/initialization.py
@@ -68,19 +68,11 @@ def init_param(m, **kwargs):
 
     elif isinstance(m, nn.Linear):
         # PyToch's default initalization
-        for name, param in m.named_parameters():
-            if "weight" in name:
-                if param.ndim >= 2:
-                    # Most common case
-                    init.kaiming_uniform_(param.data, a=sqrt(5))
-                else:
-                    init.normal_(param.data)
-            elif "bias" in name:
-                fan_in, _ = init._calculate_fan_in_and_fan_out(param.data)
-                bound = 1 / sqrt(fan_in) if fan_in > 0 else 0
-                init.uniform_(param.data, -bound, bound)
-            else:
-                raise pyrado.KeyErr(keys="weight or bias", container=param)
+        init.kaiming_uniform_(m.weight, a=sqrt(5))
+        if m.bias is not None:
+            fan_in, _ = init._calculate_fan_in_and_fan_out(m.weight)
+            bound = 1 / sqrt(fan_in) if fan_in > 0 else 0
+            init.uniform_(m.bias, -bound, bound)
 
     elif isinstance(m, (nn.RNN, nn.GRU, nn.GRUCell)):
         # PyToch's default initalization

--- a/Pyrado/pyrado/policies/initialization.py
+++ b/Pyrado/pyrado/policies/initialization.py
@@ -67,7 +67,7 @@ def init_param(m, **kwargs):
             init.normal_(m.data)
 
     elif isinstance(m, nn.Linear):
-        # PyToch's default initalization
+        # PyTorch's default initialization
         init.kaiming_uniform_(m.weight, a=sqrt(5))
         if m.bias is not None:
             fan_in, _ = init._calculate_fan_in_and_fan_out(m.weight)
@@ -75,7 +75,7 @@ def init_param(m, **kwargs):
             init.uniform_(m.bias, -bound, bound)
 
     elif isinstance(m, (nn.RNN, nn.GRU, nn.GRUCell)):
-        # PyToch's default initalization
+        # PyTorch's default initialization
         stdv = 1.0 / sqrt(m.hidden_size)
         for name, param in m.named_parameters():
             init.uniform_(param, -stdv, stdv)


### PR DESCRIPTION
Currently evaluating with four seeds respectively
Seeds are:
- 329
- 835
- 1875
- 2921
- [x] FNN (`qq_su-ppo.py`)
- [x] RNN (`qq_su-ppo.py`)
- [x] Mujoco env (`hop_ppo.py`)

# Results
## FNN
<details>
<summary>Old Init</summary>

![image](https://user-images.githubusercontent.com/4395770/120940112-debe7400-c71b-11eb-91a7-cf78b99112e5.png)

</details>
<details>
<summary>New Init</summary>

![image](https://user-images.githubusercontent.com/4395770/121003329-b40d0380-c78d-11eb-8192-d2bfd88de9ae.png)

</details>

## RNN
<details>
<summary>Old Init</summary>

![image](https://user-images.githubusercontent.com/4395770/121026106-1a9e1b80-c7a6-11eb-8aab-56b9658c4824.png)

</details>
<details>
<summary>New Init</summary>

![image](https://user-images.githubusercontent.com/4395770/121015558-6dbea100-c79b-11eb-922e-61796d95b67b.png)

</details>

## Mujoco env
<details>
<summary>Old Init</summary>

![image](https://user-images.githubusercontent.com/4395770/121075731-d6c30a80-c7d5-11eb-8fb1-4c712589d431.png)


</details>
<details>
<summary>New Init</summary>

![image](https://user-images.githubusercontent.com/4395770/121083636-f9f2b780-c7df-11eb-967f-7b3b790d5c5b.png)

</details>


