### PR TITLE
Fixing the torch and sbi version to the last actively tested ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The focus is on robotics tasks with mostly continuous control.
 It features __randomizable simulations__ written __in standalone Python__ (no license required) as well as simulations driven by the physics engines __Bullet__ (no license required), __Vortex__ (license required), __or MuJoCo__ (license required).
 
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-green.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![Documentation](https://github.com/famura/SimuRLacra/workflows/Documentation/badge.svg?branch=master)](https://famura.github.io/SimuRLacra/)
+[![Documentation](https://img.shields.io/badge/docs-informational)](https://famura.github.io/SimuRLacra/)
 [![codestyle](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![isort](https://img.shields.io/badge/imports-isort-green)](https://pycqa.github.io/isort/)
 <!-- [![codecov](https://codecov.io/gh/famura/SimuRLacra/branch/master/graph/badge.svg)](https://codecov.io/gh/famura/SimuRLacra) -->

--- a/setup_deps.py
+++ b/setup_deps.py
@@ -560,7 +560,7 @@ def setup_pytorch_based():
     # Set up SBI without touching the PyTorch installation (requires Pyro and pyknos which requires nflows)
     sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "nflows"])
     sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "pyknos"])
-    sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "sbi"])
+    sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "sbi==0.12.0"])  # 0.18 is the last version before arviz
     # Downgrade to avoid the incompatibility with cliff (whatever cliff is)
     sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "prettytable==0.7.2"])
 

--- a/setup_deps.py
+++ b/setup_deps.py
@@ -218,7 +218,6 @@ rcspysim_cmake_vars = {
     "PYBIND11_PYTHON_VERSION": "3.7",
     "SETUP_PYTHON_DEVEL": "ON",
     "Rcs_DIR": rcs_build_dir,
-    "USE_LIBTORCH": uselibtorch,  # use the manually build PyTorch from thirdParty/pytorch
     # Do NOT set CMAKE_PREFIX_PATH here, it will get overridden later on.
 }
 
@@ -551,9 +550,9 @@ def setup_pytorch_based():
     # Set up GPyTorch without touching the PyTorch installation (requires scikit-learn which requires threadpoolctl)
     sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "threadpoolctl"])
     sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "scikit-learn"])
-    sp.check_call([sys.executable, "-m", "pip", "install", "-U", "gpytorch"])
+    sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "gpytorch"])
     # Set up BoTorch without touching the PyTorch installation (requires gpytorch)
-    sp.check_call([sys.executable, "-m", "pip", "install", "-U", "botorch"])
+    sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "botorch"])
     # Set up Pyro without touching the PyTorch installation (requires opt-einsum)
     sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "opt-einsum"])
     sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "pyro-api"])

--- a/setup_deps.py
+++ b/setup_deps.py
@@ -560,7 +560,9 @@ def setup_pytorch_based():
     # Set up SBI without touching the PyTorch installation (requires Pyro and pyknos which requires nflows)
     sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "nflows"])
     sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "pyknos"])
-    sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "sbi==0.12.0"])  # 0.18 is the last version before arviz
+    sp.check_call(
+        [sys.executable, "-m", "pip", "install", "-U", "--no-deps", "sbi==0.12.0"]
+    )  # 0.18 is the last version before arviz
     # Downgrade to avoid the incompatibility with cliff (whatever cliff is)
     sp.check_call([sys.executable, "-m", "pip", "install", "-U", "--no-deps", "prettytable==0.7.2"])
 


### PR DESCRIPTION
So the thing is that the two flavors with build the `libtorch.so` could be removed if we would update to the latest torch v1.X

As nice as it sounds, this requires a lot of effort, i.e.:
1. Removing the entire block with `USE_LIBTORCH` in `rcspysim` (CMakeLists and the root setup.py) 
2. Replacing `to.lstsq(self.conds[:, idx_act], feats).solution` with `to.linalg.lstsq(feats, self.conds[:, idx_act]).solution` in `ploy_time.py

In fact, I think we could even just install torch and all the torch-dependent libs in `setup_deps.py` simply with pip and make everything way cleaner. Unfortunately, I do not have the time for that and rather archive this project at the last state where I know it worked. Therefore, I undid the recent change that removed the `--no-deps` when installing gpytorch and botorch.